### PR TITLE
Ignore extraneous columns

### DIFF
--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -99,7 +99,22 @@ class Feed(object):
         with open(path, "rb") as f:
             encoding = detect_encoding(f)
 
-        df = pd.read_csv(path, dtype=np.unicode, encoding=encoding, index_col=False)
+        # Obtain number of columns to use when reading CSV as to process rows with
+        # extraneous columns that would otherwise throw an error.
+        # Only uses first N columns where N is the number of columns.
+        num_columns = len(
+            pd.read_csv(
+                path, dtype=np.unicode, encoding=encoding, index_col=False, nrows=1
+            ).columns
+        )
+
+        df = pd.read_csv(
+            path,
+            dtype=np.unicode,
+            encoding=encoding,
+            index_col=False,
+            usecols=[i for i in range(num_columns)],
+        )
 
         # Strip leading/trailing whitespace from column names
         df.rename(columns=lambda x: x.strip(), inplace=True)


### PR DESCRIPTION
In the routes.csv file of the TTC's GTFS one of the routes
has a trailing comma while the other rows including the
header do not. This likely because the file was manually
edited in Excel (the row also happened to be a seasonal
route that was supposed to be cut due to the pandemic but
was restored at the last minute).

As we have a nightly batch that re-fetches the latest GTFS
each time manually editing the GTFS wasn't an option.

This PR changes the pandas read_csv call to read the first
N columns where N is the number of columns that read_csv
read for the first row of the CSV. This will result in the
rows with extraneous columns still being processed without
any errors.